### PR TITLE
Timetable Create & Update

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'edu.nbu.team13'
@@ -37,4 +38,9 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/controllers/SubjectController.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/controllers/SubjectController.java
@@ -2,6 +2,7 @@ package edu.nbu.team13.gradecenter.controllers;
 
 import edu.nbu.team13.gradecenter.dtos.SubjectDto;
 import edu.nbu.team13.gradecenter.entities.Subject;
+import edu.nbu.team13.gradecenter.repositories.views.SubjectTeacherView;
 import edu.nbu.team13.gradecenter.services.SubjectService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -50,4 +51,11 @@ public class SubjectController {
         subjectService.delete(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @GetMapping("/teachers/{id}")
+    public ResponseEntity<List<SubjectTeacherView>> getSubjectsWithTeachers(@PathVariable Long id) {
+        List<SubjectTeacherView> subjects = subjectService.findAllWithTeachers(id);
+        return ResponseEntity.ok(subjects);
+    }
+
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/controllers/TimetableController.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/controllers/TimetableController.java
@@ -1,0 +1,35 @@
+package edu.nbu.team13.gradecenter.controllers;
+
+import edu.nbu.team13.gradecenter.dtos.TimetableDto;
+import edu.nbu.team13.gradecenter.entities.Timetable;
+import edu.nbu.team13.gradecenter.services.TimetableService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/timetables")
+public class TimetableController {
+    private final TimetableService timetableService;
+
+    public TimetableController(TimetableService timetableService) {
+        this.timetableService = timetableService;
+    }
+
+    @GetMapping("/{schoolYearId}/{classId}")
+    public ResponseEntity<Timetable> show(@PathVariable Long schoolYearId, @PathVariable Long classId) {
+        Timetable timetable = timetableService.findBySchoolYearIdAndClassId(schoolYearId, classId);
+
+        if(timetable == null) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+
+        return ResponseEntity.ok(timetable);
+    }
+
+    @PostMapping
+    public ResponseEntity<Timetable> create(@RequestBody TimetableDto timetableDto) {
+        Timetable created = timetableService.create(timetableDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/dtos/TimetableDto.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/dtos/TimetableDto.java
@@ -1,0 +1,18 @@
+package edu.nbu.team13.gradecenter.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TimetableDto {
+    private Long id;
+
+    private Long schoolYearId;
+
+    private Long classId;
+
+    @JsonProperty("subjects")
+    private TimetableSubjectDto[] subjects;
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/dtos/TimetableSubjectDto.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/dtos/TimetableSubjectDto.java
@@ -1,0 +1,24 @@
+package edu.nbu.team13.gradecenter.dtos;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TimetableSubjectDto {
+    private Long subjectId;
+    private Long teacherId;
+    private byte dayOfWeek;
+    private int startTime;
+
+    public TimetableSubjectDto() {
+    }
+
+    public TimetableSubjectDto(Long subjectId, Long teacherId, byte dayOfWeek, int startTime) {
+        this.subjectId = subjectId;
+        this.teacherId = teacherId;
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+    }
+
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Class.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Class.java
@@ -28,5 +28,10 @@ public class Class {
     @Setter
     @Column(name = "school_id", nullable = false)
     private Long schoolId;
-
+    public Class() {}
+    public void FromDto(edu.nbu.team13.gradecenter.dtos.ClassDto dto){
+        this.name = dto.getName();
+        this.grade = dto.getGrade();
+        this.schoolId = dto.getSchoolId();
+    }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Grade.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Grade.java
@@ -43,4 +43,14 @@ public class Grade {
     @Setter
     @Column(name = "school_year_id", nullable = false)
     private Long schoolYearId;
+
+    public Grade() {}
+    public void FromDto(edu.nbu.team13.gradecenter.dtos.GradeDto dto){
+        this.date = dto.getDate();
+        this.studentId = dto.getStudentId();
+        this.teacherId = dto.getTeacherId();
+        this.subjectId = dto.getSubjectId();
+        this.schoolYearId = dto.getSchoolYearId();
+        this.value = dto.getValue();
+    }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/SchoolYear.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/SchoolYear.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 @Table(
         name = "school_years",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"year", "term", "school_id"}   // every school can have that year only once
+                columnNames = {"school_year", "term", "school_id"}   // every school can have that year only once
         )
 )
 public class SchoolYear {
@@ -26,7 +26,7 @@ public class SchoolYear {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)           // 2024 means 2024/2025 school year
+    @Column(name = "school_year", nullable = false)          // 2024 means 2024/2025 school year
     private Short year;
 
     @Column(nullable = false)           // 1 or 2

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Timetable.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/Timetable.java
@@ -1,0 +1,37 @@
+package edu.nbu.team13.gradecenter.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Entity
+@Data
+@Table(name = "timetables")
+public class Timetable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @Getter
+    @ManyToOne
+    private SchoolYear schoolYear;
+
+    @Setter
+    @Getter
+    @ManyToOne
+    @JsonProperty("class")
+    private Class clazz;
+
+    @OneToMany(mappedBy = "timetable", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TimetableSubject> subjects = new ArrayList<>();
+
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/TimetableSubject.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/TimetableSubject.java
@@ -1,0 +1,45 @@
+package edu.nbu.team13.gradecenter.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Data
+@Table(name = "timetable_subjects")
+public class TimetableSubject {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @Getter
+    @ManyToOne
+    @JsonIgnore
+    private Timetable timetable;
+
+    @Setter
+    @Getter
+    @ManyToOne
+    private Subject subject;
+
+    @Setter
+    @Getter
+    @ManyToOne
+    private Teacher teacher;
+
+    @Setter
+    @Getter
+    @Column(name = "day")
+    private byte dayOfWeek;
+
+
+    @Setter
+    @Getter
+    @Column(name = "start_time")
+    private int startTime;
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/entities/User.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/entities/User.java
@@ -2,6 +2,7 @@ package edu.nbu.team13.gradecenter.entities;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.nbu.team13.gradecenter.dtos.UserDto;
 import edu.nbu.team13.gradecenter.entities.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -59,4 +60,11 @@ public class User {
     @Column(name = "updated_on", nullable = false)
     private Instant updatedOn;
 
+    public User() {}
+    public void FromDto(UserDto dto){
+        this.firstName = dto.getFirstName();
+        this.lastName = dto.getLastName();
+        this.email = dto.getEmail();
+        this.password = dto.getPassword();
+    }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/InvalidDayOfWeek.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/InvalidDayOfWeek.java
@@ -1,0 +1,7 @@
+package edu.nbu.team13.gradecenter.exceptions;
+
+public class InvalidDayOfWeek extends RuntimeException {
+    public InvalidDayOfWeek(byte id) {
+        super("Invalid day of week:" + id);
+    }
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/TeacherDoesNotTeachSubject.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/TeacherDoesNotTeachSubject.java
@@ -1,0 +1,7 @@
+package edu.nbu.team13.gradecenter.exceptions;
+
+public class TeacherDoesNotTeachSubject extends RuntimeException {
+    public TeacherDoesNotTeachSubject(Long id, String subjectName) {
+        super("Teacher with ID " + id + " does not teach the subject " + subjectName + ".");
+    }
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/TimetableNotFound.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/exceptions/TimetableNotFound.java
@@ -1,0 +1,7 @@
+package edu.nbu.team13.gradecenter.exceptions;
+
+public class TimetableNotFound extends RuntimeException {
+    public TimetableNotFound(Long id) {
+        super("Class not found with ID: " + id);
+    }
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/SubjectRepository.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/SubjectRepository.java
@@ -1,10 +1,25 @@
 package edu.nbu.team13.gradecenter.repositories;
 
 import edu.nbu.team13.gradecenter.entities.Subject;
+import edu.nbu.team13.gradecenter.repositories.views.SubjectTeacherView;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface SubjectRepository extends JpaRepository<Subject, Long>{
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
     List<Subject> findAllBySchoolId(Long schoolId);
+
+    @Query(value = """
+        SELECT subjects.id AS subject_id,
+               subjects.name AS subject_name,
+               teachers.id AS teacher_id,
+               CONCAT(users.first_name, ' ', users.last_name) AS teacher_name
+        FROM subjects
+        JOIN teacher_subject ON teacher_subject.subject_id = subjects.id
+        JOIN teachers ON teachers.id = teacher_subject.teacher_id
+        JOIN users ON users.id = teachers.user_id
+        WHERE subjects.school_id = :schoolId
+    """, nativeQuery = true)
+    List<SubjectTeacherView> findAllWithTeachers(Long schoolId);
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/TimetableRepository.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/TimetableRepository.java
@@ -1,0 +1,14 @@
+package edu.nbu.team13.gradecenter.repositories;
+
+import edu.nbu.team13.gradecenter.entities.Class;
+import edu.nbu.team13.gradecenter.entities.SchoolYear;
+import edu.nbu.team13.gradecenter.entities.Timetable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+
+    Timetable findBySchoolYearAndClazz(SchoolYear schoolYear, Class clazz);
+
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/TimetableSubjectRepository.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/TimetableSubjectRepository.java
@@ -1,0 +1,12 @@
+package edu.nbu.team13.gradecenter.repositories;
+
+import edu.nbu.team13.gradecenter.entities.Timetable;
+import edu.nbu.team13.gradecenter.entities.TimetableSubject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TimetableSubjectRepository extends JpaRepository<TimetableSubject, Long> {
+    void deleteByTimetable(Timetable timetable);
+
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/views/SubjectTeacherView.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/repositories/views/SubjectTeacherView.java
@@ -1,0 +1,11 @@
+package edu.nbu.team13.gradecenter.repositories.views;
+
+public interface SubjectTeacherView {
+    Long getSubjectId();
+
+    String getSubjectName();
+
+    Long getTeacherId();
+
+    String getTeacherName();
+}

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/seeders/SchoolAndSubjectSeeder.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/seeders/SchoolAndSubjectSeeder.java
@@ -9,6 +9,7 @@ import edu.nbu.team13.gradecenter.entities.enums.UserRole;
 import edu.nbu.team13.gradecenter.services.*;
 import jakarta.transaction.Transactional;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.HashSet;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 @Component
+@Profile("!test")
 public class SchoolAndSubjectSeeder implements CommandLineRunner {
     private final SchoolService schoolService;
 

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/seeders/SchoolAndSubjectSeeder.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/seeders/SchoolAndSubjectSeeder.java
@@ -1,15 +1,19 @@
 package edu.nbu.team13.gradecenter.seeders;
 
-import edu.nbu.team13.gradecenter.dtos.SchoolDto;
-import edu.nbu.team13.gradecenter.dtos.SubjectDto;
+import edu.nbu.team13.gradecenter.dtos.*;
+import edu.nbu.team13.gradecenter.entities.Class;
 import edu.nbu.team13.gradecenter.entities.School;
-import edu.nbu.team13.gradecenter.services.SchoolService;
-import edu.nbu.team13.gradecenter.services.SubjectService;
+import edu.nbu.team13.gradecenter.entities.Student;
+import edu.nbu.team13.gradecenter.entities.Subject;
+import edu.nbu.team13.gradecenter.entities.enums.UserRole;
+import edu.nbu.team13.gradecenter.services.*;
 import jakarta.transaction.Transactional;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class SchoolAndSubjectSeeder implements CommandLineRunner {
@@ -17,9 +21,31 @@ public class SchoolAndSubjectSeeder implements CommandLineRunner {
 
     private final SubjectService subjectService;
 
-    public SchoolAndSubjectSeeder(SchoolService schoolService, SubjectService subjectService) {
+    private final UserService userService;
+
+    private final ClassService classService;
+
+    private final StudentService studentService;
+
+    private final TeacherService teacherService;
+    private final SchoolYearService schoolYearService;
+
+    public SchoolAndSubjectSeeder(
+            SchoolService schoolService,
+            SubjectService subjectService,
+            UserService userService,
+            ClassService classService,
+            StudentService studentService,
+            TeacherService teacherService,
+            SchoolYearService schoolYearService
+    ) {
         this.schoolService = schoolService;
         this.subjectService = subjectService;
+        this.userService = userService;
+        this.classService = classService;
+        this.studentService = studentService;
+        this.teacherService = teacherService;
+        this.schoolYearService = schoolYearService;
     }
 
     @Override
@@ -44,5 +70,59 @@ public class SchoolAndSubjectSeeder implements CommandLineRunner {
             subjectDto.setSchoolId(school.getId());
             subjectService.create(subjectDto);
         }
+
+
+        SchoolDto schoolDto2 = new SchoolDto();
+        schoolDto2.setName("ПГ по транспорт \"Хенри Форд\" ");
+        schoolDto2.setAddress("бул. Цариградско шосе 7, гр. София, България");
+        School school2 = schoolService.create(schoolDto2);
+
+        ParentDto parentDto = new ParentDto();
+        parentDto.setEmail("ivan.ivanov@parent.com");
+        parentDto.setPassword("password123");
+        parentDto.setFirstName("Иван");
+        parentDto.setLastName("Иванов");
+        parentDto.setSchoolId(school2.getId());
+
+        userService.create(parentDto, UserRole.PARENT);
+
+        ClassDto classDto = new ClassDto("A", school.getId(), 10L);
+        classDto.setGrade(10L);
+        classDto.setSchoolId(school.getId());
+        classDto.setName("А");
+
+        Class classEntity = classService.create(classDto);
+
+        ClassDto classDto2 = new ClassDto("A", school.getId(), 11L);
+        classDto.setName("B");
+
+        Class classEntity2 = classService.create(classDto2);
+
+        StudentDto studentDto = new StudentDto();
+        studentDto.setEmail("georgi.ivanov@parent.com");
+        studentDto.setPassword("password321");
+        studentDto.setFirstName("Георги");
+        studentDto.setLastName("Иванов");
+        studentDto.setGrade(10L);
+        studentDto.setClassId(classEntity.getId());
+        studentDto.setSchoolId(classEntity.getSchoolId());
+        Student student = studentService.create(studentDto);
+
+        TeacherDto teacherDto = new TeacherDto();
+        List<Subject> teacherSubjects = subjectService.findAllById(Set.of(1L, 2L, 3L));
+        teacherDto.setSubjects(new HashSet<>(teacherSubjects));
+        teacherDto.setSchoolId(school.getId());
+        teacherDto.setEmail("vyara.nesterova@teacher.com");
+        teacherDto.setPassword("password321");
+        teacherDto.setFirstName("Вяра");
+        teacherDto.setLastName("Нестерова");
+        TeacherDto teacher = teacherService.create(teacherDto);
+
+        SchoolYearDto schoolYear = new SchoolYearDto();
+        schoolYear.setSchoolId(school.getId());
+        schoolYear.setYear((short) 2024);
+        schoolYear.setTerm((byte) 1);
+        schoolYearService.create(schoolYear);
+
     }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/services/SchoolYearService.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/services/SchoolYearService.java
@@ -35,7 +35,7 @@ public class SchoolYearService {
     public SchoolYear update(Long id, SchoolYearDto dto) {
         validate(dto);
 
-        SchoolYear sy = repo.findById(id).orElseThrow(() -> new SchoolYearNotFound(id));
+        SchoolYear sy = this.findById(id);
 
         boolean changingKey =
                 sy.getYear()     != dto.getYear()  ||
@@ -77,5 +77,9 @@ public class SchoolYearService {
         sy.setTerm(d.getTerm());
         sy.setSchoolId(d.getSchoolId());
         return sy;
+    }
+
+    public SchoolYear findById(Long id) {
+        return repo.findById(id).orElseThrow(() -> new SchoolYearNotFound(id));
     }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/services/SubjectService.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/services/SubjectService.java
@@ -4,6 +4,7 @@ import edu.nbu.team13.gradecenter.dtos.SubjectDto;
 import edu.nbu.team13.gradecenter.entities.Subject;
 import edu.nbu.team13.gradecenter.exceptions.SubjectNotFound;
 import edu.nbu.team13.gradecenter.repositories.SubjectRepository;
+import edu.nbu.team13.gradecenter.repositories.views.SubjectTeacherView;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -94,5 +95,9 @@ public class SubjectService {
      */
     public List<Subject> findAllById(Set<Long> subjectIds) {
         return subjectRepository.findAllById(subjectIds);
+    }
+
+    public List<SubjectTeacherView> findAllWithTeachers(Long schoolId) {
+        return subjectRepository.findAllWithTeachers(schoolId);
     }
 }

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/services/TeacherService.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/services/TeacherService.java
@@ -125,6 +125,17 @@ public class TeacherService {
     }
 
     /**
+     * Finds a teacher by ID.
+     *
+     * @param id the ID of the teacher to find
+     * @return the found teacher entity
+     */
+    public Teacher findById(Long id) {
+        return teacherRepository.findById(id)
+                .orElseThrow(() -> new TeacherNotFound(id));
+    }
+
+    /**
      * Finds teachers by optional filters - first name, last name, email, school ID, and user ID.
      *
      * @param firstName search filter for first name

--- a/backend/src/main/java/edu/nbu/team13/gradecenter/services/TimetableService.java
+++ b/backend/src/main/java/edu/nbu/team13/gradecenter/services/TimetableService.java
@@ -1,0 +1,74 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.TimetableDto;
+import edu.nbu.team13.gradecenter.dtos.TimetableSubjectDto;
+import edu.nbu.team13.gradecenter.entities.Class;
+import edu.nbu.team13.gradecenter.entities.*;
+import edu.nbu.team13.gradecenter.exceptions.InvalidDayOfWeek;
+import edu.nbu.team13.gradecenter.exceptions.TeacherDoesNotTeachSubject;
+import edu.nbu.team13.gradecenter.repositories.TimetableRepository;
+import edu.nbu.team13.gradecenter.repositories.TimetableSubjectRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TimetableService {
+    private final TimetableRepository timetableRepository;
+    private final TimetableSubjectRepository timetableSubjectRepository;
+
+    private final SchoolYearService schoolYearService;
+    private final ClassService classService;
+
+    private final SubjectService subjectService;
+    private final TeacherService teacherService;
+
+    @Transactional
+    public Timetable create(TimetableDto timetableDto) {
+        SchoolYear schoolYear = schoolYearService.findById(timetableDto.getSchoolYearId());
+        Class clazz = classService.findById(timetableDto.getClassId());
+
+        Timetable timetable = timetableRepository.findBySchoolYearAndClazz(schoolYear, clazz);
+
+        if (timetable == null) {
+            timetable = new Timetable();
+            timetable.setSchoolYear(schoolYear);
+            timetable.setClazz(clazz);
+            timetable = timetableRepository.save(timetable);
+        } else {
+            timetableSubjectRepository.deleteByTimetable(timetable);
+        }
+
+        for (TimetableSubjectDto subjectDto : timetableDto.getSubjects()) {
+            Subject subject = subjectService.findById(subjectDto.getSubjectId());
+            Teacher teacher = teacherService.findById(subjectDto.getTeacherId());
+
+            if (subjectDto.getDayOfWeek() < 1 || subjectDto.getDayOfWeek() > 7) {
+                throw new InvalidDayOfWeek(subjectDto.getDayOfWeek());
+            }
+
+            if (!teacher.getSubjects().contains(subject)) {
+                throw new TeacherDoesNotTeachSubject(teacher.getId(), subject.getName());
+            }
+
+            TimetableSubject timetableSubject = new TimetableSubject();
+            timetableSubject.setSubject(subject);
+            timetableSubject.setTeacher(teacher);
+            timetableSubject.setDayOfWeek(subjectDto.getDayOfWeek());
+            timetableSubject.setStartTime(subjectDto.getStartTime());
+            timetableSubject.setTimetable(timetable);
+            TimetableSubject newTimetableSubject = timetableSubjectRepository.save(timetableSubject);
+            timetable.getSubjects().add(newTimetableSubject);
+        }
+
+        return timetable;
+    }
+
+    public Timetable findBySchoolYearIdAndClassId(Long schoolYearId, Long classId) {
+        SchoolYear schoolYear = schoolYearService.findById(schoolYearId);
+        Class clazz = classService.findById(classId);
+
+        return timetableRepository.findBySchoolYearAndClazz(schoolYear, clazz);
+    }
+}

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/controllers/SubjectControllerTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/controllers/SubjectControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class SubjectControllerTest {
     @Autowired
     private SubjectService subjectService;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/controllers/TeacherControllerTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/controllers/TeacherControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class TeacherControllerTest {
     @Autowired
     private TeacherRepository teacherRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/repositories/TeacherRepositoryTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/repositories/TeacherRepositoryTest.java
@@ -3,9 +3,11 @@ package edu.nbu.team13.gradecenter.repositories;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class TeacherRepositoryTest {
 
     @Autowired

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/repositories/UserRepositoryTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/repositories/UserRepositoryTest.java
@@ -1,20 +1,20 @@
 package edu.nbu.team13.gradecenter.repositories;
 
-import edu.nbu.team13.gradecenter.dtos.SchoolDto;
 import edu.nbu.team13.gradecenter.entities.School;
 import edu.nbu.team13.gradecenter.entities.User;
 import edu.nbu.team13.gradecenter.entities.enums.UserRole;
-import edu.nbu.team13.gradecenter.services.SchoolService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class UserRepositoryTest {
 
     @Autowired
@@ -23,17 +23,14 @@ public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private SchoolService schoolService;
-
     private School school;
 
     @BeforeEach
     void setUp() {
-        SchoolDto schoolDto = new SchoolDto();
-        schoolDto.setName("Test School");
-        schoolDto.setAddress("Test Address");
-        school = schoolService.create(schoolDto);
+        school = new School();
+        school.setName("Test School");
+        school.setAddress("Test Address");
+        entityManager.persistAndFlush(school);
     }
 
     @Test

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/AbsenceServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/AbsenceServiceTest.java
@@ -1,0 +1,82 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.AbsenceDto;
+import edu.nbu.team13.gradecenter.dtos.SchoolDto;
+import edu.nbu.team13.gradecenter.entities.Absence;
+import edu.nbu.team13.gradecenter.repositories.AbsenceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class AbsenceServiceTest {
+    @Mock
+    private AbsenceRepository absenceRepository;
+    private AbsenceService absenceService;
+    private AbsenceDto absenceDto;
+
+    @BeforeEach
+    void setUp() {
+        absenceService = new AbsenceService(absenceRepository);
+        absenceDto = new AbsenceDto();
+        absenceDto.setDate(LocalDate.of(2020, 1, 1));
+        absenceDto.setReason("Test Reason");
+        absenceDto.setExcused(true);
+        absenceDto.setTeacherId(1L);
+        absenceDto.setStudentId(1L);
+    }
+
+    @Test
+    public void create() {
+        var abscence = new Absence();
+        abscence.FromDto(absenceDto);
+
+        Mockito.when(absenceRepository.save(any())).thenReturn(abscence);
+
+        var result = absenceService.create(absenceDto);
+        assertEquals(abscence.getReason(),result.getReason());
+
+    }
+    @Test
+    public void update() {
+        var abscence = new Absence();
+        abscence.FromDto(absenceDto);
+        abscence.setReason("Updated Reason");
+
+        Mockito.when(absenceRepository.save(any())).thenReturn(abscence);
+        Mockito.when(absenceRepository.findById(1L)).thenReturn(Optional.of(abscence));
+
+        var result = absenceService.update(1L,absenceDto);
+        assertEquals(abscence.getReason(),result.getReason());
+    }
+    @Test
+    public void findById() {
+        var abscence = new Absence();
+        abscence.FromDto(absenceDto);
+        Mockito.when(absenceRepository.findById(1L)).thenReturn(Optional.of(abscence));
+
+        var result = absenceService.findById(1L);
+        assertEquals(abscence.getReason(),result.getReason());
+
+    }
+    @Test
+    public void delete() {
+        var abscence = new Absence();
+        abscence.FromDto(absenceDto);
+        Mockito.when(absenceRepository.findById(1L)).thenReturn(Optional.of(abscence));
+        absenceService.delete(1L);
+    }
+}

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/AbsenceServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/AbsenceServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -22,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class AbsenceServiceTest {
     @Mock
     private AbsenceRepository absenceRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/ClassServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/ClassServiceTest.java
@@ -1,0 +1,81 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.ClassDto;
+import edu.nbu.team13.gradecenter.entities.Class;
+import edu.nbu.team13.gradecenter.repositories.ClassRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class ClassServiceTest {
+    @Mock
+    private ClassRepository classRepository;
+    private ClassService classService;
+    private ClassDto classDto;
+
+    @BeforeEach
+    void setUp() {
+        classService = new ClassService(classRepository);
+        classDto = new ClassDto();
+        classDto.setName("Test Class");
+        classDto.setSchoolId(1L);
+        classDto.setGrade(11L);
+
+    }
+
+    @Test
+    public void create() {
+        var cls = new Class();
+        cls.FromDto(classDto);
+
+        Mockito.when(classRepository.save(any())).thenReturn(cls);
+
+        var result = classService.create(classDto);
+        assertEquals(cls.getGrade(),result.getGrade());
+
+    }
+    @Test
+    public void update() {
+        var cls = new Class();
+        cls.FromDto(classDto);
+        cls.setGrade(12L);
+
+        Mockito.when(classRepository.findById(1L)).thenReturn(Optional.of(cls));
+        Mockito.when(classRepository.save(any())).thenReturn(cls);
+
+
+        var result = classService.update(1L,classDto);
+        assertEquals(cls.getGrade(),result.getGrade());
+    }
+    @Test
+    public void findById() {
+        var cls = new Class();
+        cls.FromDto(classDto);
+
+        Mockito.when(classRepository.findById(1L)).thenReturn(Optional.of(cls));
+
+        var result = classService.findById(1L);
+        assertEquals(cls.getGrade(),result.getGrade());
+
+    }
+    @Test
+    public void delete() {
+        var cls = new Class();
+        cls.FromDto(classDto);
+        cls.setGrade(12L);
+
+        Mockito.when(classRepository.findById(1L)).thenReturn(Optional.of(cls));
+        classService.delete(1L);
+    }
+}

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/ClassServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/ClassServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
@@ -18,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class ClassServiceTest {
     @Mock
     private ClassRepository classRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/DirectorServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/DirectorServiceTest.java
@@ -1,0 +1,91 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.DirectorDto;
+import edu.nbu.team13.gradecenter.dtos.GradeDto;
+import edu.nbu.team13.gradecenter.entities.Grade;
+import edu.nbu.team13.gradecenter.entities.User;
+import edu.nbu.team13.gradecenter.entities.enums.UserRole;
+import edu.nbu.team13.gradecenter.repositories.DirectorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class DirectorServiceTest {
+    @Mock
+    private DirectorRepository directorRepository;
+    @Mock
+    private SchoolService schoolService;
+    @Mock
+    private UserService userService;
+    private DirectorService directorService;
+    private DirectorDto directorDto;
+
+    @BeforeEach
+    void setUp() {
+        directorService = new DirectorService(directorRepository, schoolService, userService);
+        directorDto = new DirectorDto();
+        directorDto.setId(1L);
+        directorDto.setFirstName("John");
+        directorDto.setLastName("Doe");
+        directorDto.setSchoolId(1L);
+        directorDto.setEmail("main@main.bg");
+        directorDto.setPassword("password");
+    }
+    @Test
+    public void create() {
+        var director = new User();
+        director.FromDto(directorDto);
+
+        Mockito.when(schoolService.hasDirector(any())).thenReturn(false);
+        Mockito.when(userService.create(any(),any())).thenReturn(director);
+
+        var result = directorService.create(directorDto);
+        assertEquals(director.getEmail(),result.getEmail());
+
+    }
+    @Test
+    public void update() {
+        var director = new User();
+        directorDto.setEmail("test@test.bg");
+        director.FromDto(directorDto);
+
+
+
+        Mockito.when(userService.update(any(),any())).thenReturn(director);
+
+        var result = directorService.update(1L,directorDto);
+        assertEquals(directorDto.getEmail(),result.getEmail());
+    }
+    @Test
+    public void findById() {
+        var director = new User();
+        director.setRole(UserRole.DIRECTOR);
+        director.FromDto(directorDto);
+
+        Mockito.when(userService.findById(any())).thenReturn(director);
+
+        var result = directorService.findById(1L);
+        assertEquals(directorDto.getEmail(),result.getEmail());
+
+    }
+    @Test
+    public void delete() {
+        var director = new User();
+        director.FromDto(directorDto);
+
+        directorService.delete(1L);
+    }
+}
+

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/DirectorServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/DirectorServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -22,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class DirectorServiceTest {
     @Mock
     private DirectorRepository directorRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/GradeServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/GradeServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class GradeServiceTest {
     @Mock
     private GradeRepository gradeRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/GradeServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/GradeServiceTest.java
@@ -1,0 +1,84 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.GradeDto;
+import edu.nbu.team13.gradecenter.entities.Class;
+import edu.nbu.team13.gradecenter.entities.Grade;
+import edu.nbu.team13.gradecenter.repositories.GradeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class GradeServiceTest {
+    @Mock
+    private GradeRepository gradeRepository;
+    private GradeService gradeService;
+    private GradeDto gradeDto;
+
+    @BeforeEach
+    void setUp() {
+        gradeService = new GradeService(gradeRepository);
+        gradeDto = new GradeDto();
+        gradeDto.setDate(LocalDate.of(2020, 1, 1));
+        gradeDto.setValue(6.0);
+        gradeDto.setTeacherId(1L);
+        gradeDto.setStudentId(1L);
+        gradeDto.setSchoolYearId(1L);
+    }
+    @Test
+    public void create() {
+        var grade = new Grade();
+        grade.FromDto(gradeDto);
+
+        Mockito.when(gradeRepository.save(any())).thenReturn(grade);
+
+        var result = gradeService.create(gradeDto);
+        assertEquals(grade.getValue(),result.getValue());
+
+    }
+    @Test
+    public void update() {
+        var grade = new Grade();
+        grade.FromDto(gradeDto);
+
+        Mockito.when(gradeRepository.save(any())).thenReturn(grade);
+
+        Mockito.when(gradeRepository.findById(1L)).thenReturn(Optional.of(grade));
+        Mockito.when(gradeRepository.save(any())).thenReturn(grade);
+
+
+        var result = gradeService.update(1L,gradeDto);
+        assertEquals(grade.getValue(),result.getValue());
+    }
+    @Test
+    public void findById() {
+        var grade = new Grade();
+        grade.FromDto(gradeDto);
+
+        Mockito.when(gradeRepository.findById(1L)).thenReturn(Optional.of(grade));
+
+        var result = gradeService.findById(1L);
+        assertEquals(grade.getValue(),result.getValue());
+
+    }
+    @Test
+    public void delete() {
+        var grade = new Grade();
+        grade.FromDto(gradeDto);
+
+        Mockito.when(gradeRepository.findById(1L)).thenReturn(Optional.of(grade));
+        gradeService.delete(1L);
+    }
+
+}

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/ParentServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/ParentServiceTest.java
@@ -1,0 +1,72 @@
+package edu.nbu.team13.gradecenter.services;
+
+import edu.nbu.team13.gradecenter.dtos.ParentDto;
+import edu.nbu.team13.gradecenter.entities.School;
+import edu.nbu.team13.gradecenter.entities.User;
+import edu.nbu.team13.gradecenter.entities.enums.UserRole;
+import edu.nbu.team13.gradecenter.repositories.ParentRepository;
+import edu.nbu.team13.gradecenter.repositories.ParentStudentRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+public class ParentServiceTest {
+    @Mock
+    private ParentRepository parentRepository;
+    @Mock
+    private ParentStudentRepository parentStudentRepository;
+    @Mock
+    private UserService userService;
+    private ParentService parentService;
+    private ParentDto parentDto;
+
+    @BeforeEach
+    void setUp() {
+        parentService = new ParentService(parentRepository,parentStudentRepository,userService);
+        parentDto = new ParentDto();
+        parentDto.setEmail("email@mail.com");
+        parentDto.setPassword("password");
+        parentDto.setFirstName("firstName");
+        parentDto.setLastName("lastName");
+        parentDto.setSchoolId(1L);
+    }
+    @Test
+    public void create() {
+        var parent = new User();
+        parent.FromDto(parentDto);
+        var school = new School();
+        school.setId(1L);
+        parent.setSchool(new edu.nbu.team13.gradecenter.entities.School());
+
+        Mockito.when(userService.create(any(), any())).thenReturn(parent);
+
+        var result = parentService.create(parentDto);
+        assertEquals(parent.getEmail(),result.getEmail());
+
+    }
+    @Test
+    public void update() {
+        var parent = new User();
+        parent.FromDto(parentDto);
+        var school = new School();
+        school.setId(1L);
+
+        Mockito.when(userService.update(any(), any())).thenReturn(parent);
+
+        var result = parentService.update(1L,parentDto);
+        assertEquals(parent.getEmail(),result.getEmail());
+    }
+}

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/ParentServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/ParentServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class ParentServiceTest {
     @Mock
     private ParentRepository parentRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/SubjectServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/SubjectServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class SubjectServiceTest {
     @Autowired
     private SubjectService subjectService;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/TeacherServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/TeacherServiceTest.java
@@ -14,12 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class TeacherServiceTest {
     @Autowired
     private TeacherRepository teacherRepository;

--- a/backend/src/test/java/edu/nbu/team13/gradecenter/services/UserServiceTest.java
+++ b/backend/src/test/java/edu/nbu/team13/gradecenter/services/UserServiceTest.java
@@ -7,6 +7,7 @@ import edu.nbu.team13.gradecenter.entities.User;
 import edu.nbu.team13.gradecenter.entities.enums.UserRole;
 import edu.nbu.team13.gradecenter.exceptions.EmailNotAvailable;
 import edu.nbu.team13.gradecenter.exceptions.UserNotFound;
+import edu.nbu.team13.gradecenter.repositories.StudentRepository;
 import edu.nbu.team13.gradecenter.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,18 +15,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private StudentRepository studentRepository;
 
     private School school;
 
@@ -35,6 +41,7 @@ public class UserServiceTest {
     @BeforeEach
     void setUp() {
         userRepository.deleteAll();
+        studentRepository.deleteAll();
 
         SchoolDto schoolDto = new SchoolDto();
         schoolDto.setName("Test School");

--- a/frontend/app/layout/Header.jsx
+++ b/frontend/app/layout/Header.jsx
@@ -24,6 +24,8 @@ export default () => {
                                 <NavLink to="/teachers">Teachers</NavLink>
                             </li>
 
+                            {/* 🆕 Parents link */}
+
                             <li>
                                 <NavLink to="/parents">Parents</NavLink>
                             </li>

--- a/frontend/app/layout/Header.jsx
+++ b/frontend/app/layout/Header.jsx
@@ -15,13 +15,15 @@ export default () => {
                                 <NavLink to="/dashboard">Dashboard</NavLink>
                             </li>
                             <li>
+                                <NavLink to="/timetables">Timetables</NavLink>
+                            </li>
+                            <li>
                                 <NavLink to="/students">Students</NavLink>
                             </li>
                             <li>
                                 <NavLink to="/teachers">Teachers</NavLink>
                             </li>
 
-                            {/* 🆕 Parents link */}
                             <li>
                                 <NavLink to="/parents">Parents</NavLink>
                             </li>

--- a/frontend/app/layout/forms/TeacherForm.jsx
+++ b/frontend/app/layout/forms/TeacherForm.jsx
@@ -1,7 +1,7 @@
 import { Form } from 'react-router';
 import React from 'react';
-import UserFields from "./components/UserFields.jsx";
-import SubjectSelect from "./components/SubjectSelect.jsx";
+import UserFields from './components/UserFields.jsx';
+import SubjectSelect from './components/SubjectSelect.jsx';
 
 export default function TeacherForm({ teacher, subjects, errors }) {
   const [firstName, setFirstName] = React.useState(teacher?.firstName || '');
@@ -15,10 +15,23 @@ export default function TeacherForm({ teacher, subjects, errors }) {
   return (
     <Form method="post">
       <fieldset className="fieldset">
-        <UserFields errors={errors} setFuncs={{setFirstName,setLastName,setEmail,setPassword,setRepeatPassword}} firstName={firstName} lastName={lastName} email={email} password={password} repeatPassword={repeatPassword} />
+        <UserFields
+          errors={errors}
+          setFuncs={{ setFirstName, setLastName, setEmail, setPassword, setRepeatPassword }}
+          firstName={firstName}
+          lastName={lastName}
+          email={email}
+          password={password}
+          repeatPassword={repeatPassword}
+        />
         <div className="mb-2">
           <label className="fieldset-label" htmlFor="subjects">Subjects</label>
-          <SubjectSelect subjects={subjects} errors={errors} user={teacher}/>
+          <SubjectSelect
+            multiselect
+            subjects={subjects}
+            errors={errors}
+            selectedIds={teacher?.subjects?.map(s => s.id)}
+          />
           {errors?.subjects &&
             <p className="text-error text-xs mt-1">{errors.subjects}</p>}
         </div>

--- a/frontend/app/layout/forms/components/ClassSelect.jsx
+++ b/frontend/app/layout/forms/components/ClassSelect.jsx
@@ -1,0 +1,12 @@
+export default function ClassSelect({ classes, onClassChanged }) {
+  return (
+    <select name="classId" id="classId" className={`mt-0.5 select w-full`} onChange={(e) => onClassChanged(e.target.value)}>
+      <option value="">Select Class</option>
+      {classes.map(item => (
+        <option key={item.id} value={item.id}>
+          {`${item.grade}${item.name}`}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/app/layout/forms/components/SubjectSelect.jsx
+++ b/frontend/app/layout/forms/components/SubjectSelect.jsx
@@ -1,14 +1,18 @@
-import React from "react";
+import React from 'react';
 
-export default function SubjectSelect({subjects,user, errors }) {
-    return (
-        <select name="subjectIds" id="subjects" multiple={true}
-                className={`mt-0.5 select w-full h-24 ${errors?.subjects ? `input-error` : ``}`}>
-            {subjects.map(subject => (
-                <option key={subject.id} value={subject.id} selected={user?.subjects?.find(s => s.id === subject.id)}>
-                    {subject.name}
-                </option>
-            ))}
-        </select>
-    )
+export default function SubjectSelect({ multiselect, subjects, selectedIds, errors, size }) {
+  return (
+    <select
+      name="subjectIds"
+      id="subjects"
+      multiple={multiselect}
+      className={`mt-0.5 select w-full ${errors?.subjects ? `input-error` : ``} ${size}`}>
+      <option>Select subject</option>
+      {subjects.map(subject => (
+        <option key={subject.id} value={subject.id} selected={selectedIds.includes(subject.id)}>
+          {subject.name}
+        </option>
+      ))}
+    </select>
+  )
 }

--- a/frontend/app/layout/forms/components/TeacherSelect.jsx
+++ b/frontend/app/layout/forms/components/TeacherSelect.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function TeacherSelect({ teachers, selectedIds, errors, size }) {
+  return (
+    <select
+      name="subjectIds"
+      id="subjects"
+      className={`mt-0.5 select w-full ${errors?.subjects ? `input-error` : ``} ${size}`}>
+      <option>Choose teacher</option>
+      {teachers.map(teacher => (
+        <option key={teacher.id} value={teacher.id} selected={selectedIds.includes(teacher.id)}>
+          {`${teacher.user.firstName} ${teacher.user.lastName}`}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/app/layout/forms/components/timetable/TimetableSubject.jsx
+++ b/frontend/app/layout/forms/components/timetable/TimetableSubject.jsx
@@ -1,0 +1,28 @@
+const formatKey = (subjectWithTeacher) => {
+  return `${subjectWithTeacher.teacherId}-${subjectWithTeacher.subjectId}`;
+}
+
+export default function TimetableSubject({ day, time, subjectsWithTeachers, selected }) {
+  console.log('Already selected', selected);
+  return (
+    <>
+      <select
+        name={`subjectWithTeacher[${day}][${time}]`}
+        id="subjectWithTeacher"
+        className="mt-0.5 select select-sm w-full">
+        <option>Select subject</option>
+        {subjectsWithTeachers.map(subjectWithTeacher => {
+          const key = formatKey(subjectWithTeacher);
+          return (
+            <option
+              key={key}
+              value={key}
+              selected={selected === key}>
+              {`${subjectWithTeacher.subjectName} (${subjectWithTeacher.teacherName})`}
+            </option>
+          );
+        })}
+      </select>
+    </>
+  )
+}

--- a/frontend/app/layout/forms/components/timetable/Week.jsx
+++ b/frontend/app/layout/forms/components/timetable/Week.jsx
@@ -28,9 +28,10 @@ export default function Week({ subjectsWithTeachers, existing }) {
                 const existingSubjectForDayAndTime = existing
                   .find(subject => subject.dayOfWeek === WEEKDAYS[day] && subject.startTime === parseTime(time));
                 if (existingSubjectForDayAndTime) {
-                  selected = `${existingSubjectForDayAndTime.subject.id}-${existingSubjectForDayAndTime.teacher.id}`;
+                  selected = `${existingSubjectForDayAndTime.teacher.id}-${existingSubjectForDayAndTime.subject.id}`;
                 }
               }
+
 
               return (
                 <React.Fragment key={`col-${index}-${dayIndex}`}>

--- a/frontend/app/layout/forms/components/timetable/Week.jsx
+++ b/frontend/app/layout/forms/components/timetable/Week.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { generateTimes, parseTime, WEEKDAYS } from '../../../../utilities/timetable';
+import TimetableSubject from './TimetableSubject';
+
+const times = generateTimes();
+
+export default function Week({ subjectsWithTeachers, existing }) {
+  return (
+    <table className="table">
+      <thead>
+      <tr>
+        {
+          Object.keys(WEEKDAYS).map((day, index) => (
+            <th key={index} className="text-center" colSpan="2">
+              {day}
+            </th>
+          ))
+        }
+      </tr>
+      </thead>
+      <tbody>
+      {times.map((time, index) => (
+        <tr key={index}>
+          {
+            Object.keys(WEEKDAYS).map((day, dayIndex) => {
+              let selected = '';
+              if (Array.isArray(existing)) {
+                const existingSubjectForDayAndTime = existing
+                  .find(subject => subject.dayOfWeek === WEEKDAYS[day] && subject.startTime === parseTime(time));
+                if (existingSubjectForDayAndTime) {
+                  selected = `${existingSubjectForDayAndTime.subject.id}-${existingSubjectForDayAndTime.teacher.id}`;
+                }
+              }
+
+              return (
+                <React.Fragment key={`col-${index}-${dayIndex}`}>
+                  <td key={`time-${index}-${dayIndex}`} className="text-right">
+                    {time}
+                  </td>
+                  <td className="p-2" key={`subject-${index}-${dayIndex}`}>
+                    <TimetableSubject
+                      subjectsWithTeachers={subjectsWithTeachers}
+                      selected={selected}
+                      day={day}
+                      time={time}
+                    />
+                  </td>
+                </React.Fragment>
+              );
+            })
+          }
+        </tr>
+      ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/app/routes.js
+++ b/frontend/app/routes.js
@@ -18,6 +18,13 @@ export default [
     route(':id/edit', 'routes/authenticated/teachers/edit.jsx'),
   ]),
 
+  /**
+   * Timetable routes
+   */
+  ...prefix('timetables', [
+    index('routes/authenticated/timetables/create.jsx')
+  ]),
+
   ...prefix('class', [
     index('routes/authenticated/class/index.jsx'),
     route(':id/edit', 'routes/authenticated/class/edit.jsx'),

--- a/frontend/app/routes/authenticated/timetables/create.jsx
+++ b/frontend/app/routes/authenticated/timetables/create.jsx
@@ -1,4 +1,4 @@
-import { Form, redirect } from 'react-router';
+import { Form } from 'react-router';
 import apiConfig from '../../../api.config';
 import settings from '../../../settings';
 import ClassSelect from '../../../layout/forms/components/ClassSelect';
@@ -48,13 +48,12 @@ export async function clientAction({ request }) {
   if (!response.ok) {
     return { errors: { general: data.message } };
   }
-
-  return redirect('/timetables');
+  return { success: true };
 }
 
 export default function CreateTimetable({ loaderData, actionData }) {
   const { subjectsWithTeachers, classes } = loaderData;
-  const { errors } = actionData || {};
+  const { errors, success } = actionData || {};
 
   const [classId, setClassId] = React.useState(null);
 
@@ -72,7 +71,7 @@ export default function CreateTimetable({ loaderData, actionData }) {
         }
       })
       .then(data => {
-        if(data) {
+        if (data) {
           setTimetable(data.subjects);
         }
       });
@@ -106,6 +105,12 @@ export default function CreateTimetable({ loaderData, actionData }) {
                   <button className="btn btn-primary mt-4 w-full" type="submit">
                     Save Timetable
                   </button>
+                  {success && (
+                    <div role="alert"
+                         className="alert alert-success mt-2">
+                      <span>Timetable successfully updated!</span>
+                    </div>
+                  )}
                 </div>
               )}
             </Form>

--- a/frontend/app/routes/authenticated/timetables/create.jsx
+++ b/frontend/app/routes/authenticated/timetables/create.jsx
@@ -1,0 +1,117 @@
+import { Form, redirect } from 'react-router';
+import apiConfig from '../../../api.config';
+import settings from '../../../settings';
+import ClassSelect from '../../../layout/forms/components/ClassSelect';
+import Week from '../../../layout/forms/components/timetable/Week';
+import { parseFormDataIntoTimetable } from '../../../utilities/timetable';
+import ErrorIcon from '../../../layout/icons/ErrorIcon';
+import React from 'react';
+
+
+export function meta() {
+  return [
+    { title: 'Timetables - Grade Center' },
+    { name: 'description', content: 'A modern web-based school grade book for teachers, students, and parents.' },
+  ];
+}
+
+export async function loader() {
+  const classesRequest = await fetch(`${apiConfig.baseUrl}/classes?schoolId=${settings.schoolId}`);
+  const classesResponse = await classesRequest.json();
+
+  const subjectsWithTeachersRequest = await fetch(`${apiConfig.baseUrl}/subjects/teachers/${settings.schoolId}`);
+  const subjectsWithTeachersResponse = await subjectsWithTeachersRequest.json();
+  return {
+    classes: classesResponse.content,
+    subjectsWithTeachers: subjectsWithTeachersResponse,
+  }
+}
+
+export async function clientAction({ request }) {
+  const formData = await request.formData();
+  const timetable = parseFormDataIntoTimetable(Object.fromEntries(formData));
+
+  const response = await fetch(`${apiConfig.baseUrl}/timetables`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      classId: formData.get('classId'),
+      schoolYearId: settings.schoolYearId,
+      subjects: timetable,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    return { errors: { general: data.message } };
+  }
+
+  return redirect('/timetables');
+}
+
+export default function CreateTimetable({ loaderData, actionData }) {
+  const { subjectsWithTeachers, classes } = loaderData;
+  const { errors } = actionData || {};
+
+  const [classId, setClassId] = React.useState(null);
+
+  const [timetable, setTimetable] = React.useState({});
+
+  React.useEffect(() => {
+    if (!classId) {
+      return;
+    }
+
+    fetch(`${apiConfig.baseUrl}/timetables/${settings.schoolYearId}/${classId}`)
+      .then(response => {
+        if (response.ok && response.status !== 204) {
+          return response.json();
+        }
+      })
+      .then(data => {
+        if(data) {
+          setTimetable(data.subjects);
+        }
+      });
+
+  }, [classId]);
+
+  return (
+    <div className="bg-base-100 text-base-content py-10 lg:py-20">
+      <div className="container mx-auto px-4">
+        <div className="card mx-auto bg-base-100 w-full shrink-0 shadow-2xl">
+          <div className="card-body">
+            <div className="flex justify-between items-center">
+              <h2 className="text-3xl font-bold">Manage Timetable</h2>
+            </div>
+            {errors?.general && (
+              <div role="alert" className="alert alert-error">
+                <ErrorIcon/>
+                <span>{errors.general}</span>
+              </div>
+            )}
+            <Form method="post">
+              <div className="mb-2">
+                <label className="fieldset-label" htmlFor="subjects">Class</label>
+                <ClassSelect classes={classes} onClassChanged={setClassId}/>
+              </div>
+              {classId && (
+                <div>
+                  <div className="overflow-x">
+                    <Week subjectsWithTeachers={subjectsWithTeachers} existing={timetable}/>
+                  </div>
+                  <button className="btn btn-primary mt-4 w-full" type="submit">
+                    Save Timetable
+                  </button>
+                </div>
+              )}
+            </Form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/settings.js
+++ b/frontend/app/settings.js
@@ -3,4 +3,5 @@
  */
 export default {
   schoolId: 1, /** @TODO: Get this from the currently authenticated user */
+  schoolYearId: 1, /** @TODO: Get this from a dropdown in the UI & load current school year or most recent by default*/
 }

--- a/frontend/app/utilities/timetable.js
+++ b/frontend/app/utilities/timetable.js
@@ -1,0 +1,84 @@
+export const WEEKDAYS = {
+  MONDAY: 1,
+  TUESDAY: 2,
+  WEDNESDAY: 3,
+  THURSDAY: 4,
+  FRIDAY: 5,
+};
+export const SHORT_BREAK_DURATION = 10;
+export const LONG_BREAK_DURATION = 20;
+export const LONG_BREAK_AFTER = 3;
+
+export function generateTimes() {
+  const earliestTime = 7.5 * 60;
+  const latestTime = 18 * 60;
+  const times = [];
+
+  let i = 1;
+
+  for (let time = earliestTime; time <= latestTime; time += 45) {
+    const hours = Math.floor(time / 60);
+    const minutes = time % 60;
+    const formattedTime = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+    times.push(formattedTime);
+    time += (i === LONG_BREAK_AFTER ? LONG_BREAK_DURATION : SHORT_BREAK_DURATION);
+    i++;
+  }
+
+  return times;
+}
+
+export function parseFormDataIntoTimetable(formData) {
+  const subjects = [];
+
+  Object.entries(formData).forEach(([key, value]) => {
+    const match = key.match(/^subjectWithTeacher\[(.*?)\]\[(.*?)\]$/);
+    if (match) {
+      const day = match[1];
+      const time = match[2];
+
+      const subjectWithTeacher = value.split('-');
+
+      if (subjectWithTeacher.length !== 2) {
+        return;
+      }
+
+      subjects.push({
+        dayOfWeek: WEEKDAYS[day.toUpperCase()],
+        startTime: parseTime(time),
+        teacherId: parseInt(subjectWithTeacher[0]),
+        subjectId: parseInt(subjectWithTeacher[1]),
+      });
+    }
+  });
+
+  return subjects;
+}
+
+
+export function parseTime(time) {
+  const [hours, minutes] = time.split(':').map(Number);
+  return (hours * 60 + minutes) * 60;
+}
+
+
+function formatTime(time) {
+  const totalMinutes = Math.floor(time / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+}
+
+
+export function parseTimetableIntoFormdata(subjects) {
+  const formData = {};
+
+  subjects.forEach(subject => {
+    const day = Object.keys(WEEKDAYS).find(key => WEEKDAYS[key] === subject.dayOfWeek);
+    const time = formatTime(subject.startTime);
+
+    formData[`subjectWithTeacher[${day}][${time}]`] = `${subject.teacherId}-${subject.subjectId}`;
+  });
+
+  return formData;
+}


### PR DESCRIPTION
This pull request introduces significant functionality related to managing timetables, including new controllers, services, entities, and exception handling. Additionally, it enhances the subject management system by adding a feature to retrieve subjects along with their associated teachers. Below are the most important changes grouped by theme:

### Timetable Management:
* Added `TimetableController` to handle API endpoints for creating and fetching timetables. (`[backend/src/main/java/edu/nbu/team13/gradecenter/controllers/TimetableController.javaR1-R35](diffhunk://#diff-dc23f4a53fa8760c9a700615b3d02660a0a0bde1dfca1b6cd7ddbb05d78a7a5bR1-R35)`)
* Introduced `TimetableService` to manage business logic for timetables, including validation and associations with school years, classes, subjects, and teachers. (`[backend/src/main/java/edu/nbu/team13/gradecenter/services/TimetableService.javaR1-R74](diffhunk://#diff-5045140d4795b1452107e3513c12d34c00d06a24b7e9bab7805f1d5b524e9415R1-R74)`)
* Created new entities `Timetable` and `TimetableSubject` to represent timetables and their associated subjects and teachers in the database. (`[[1]](diffhunk://#diff-439d3071fb33f5a2abc59505e3a1dcb8881e0162f9f54f16b2efe681b8a16e20R1-R37)`, `[[2]](diffhunk://#diff-fec2d8c6d92b7727889055195d98eb5ecc1449d3b68c979f0f7ada78ee19bf93R1-R45)`)
* Added repositories `TimetableRepository` and `TimetableSubjectRepository` for database interactions related to timetables and their subjects. (`[[1]](diffhunk://#diff-bb1645381d0a07cb4897efec45ff059f1423e7a56b15005b47bfdcc6c908e8bfR1-R14)`, `[[2]](diffhunk://#diff-0a7c916f0ba7cca9994211698cd1c3ac1f36f2de0937661ccec48c9241be0dcfR1-R12)`)
* Introduced DTOs `TimetableDto` and `TimetableSubjectDto` for transferring timetable-related data between layers. (`[[1]](diffhunk://#diff-a55ffce3f3381780a5a721bb9393b3bc5eadd881118fe596ec289e829832d019R1-R18)`, `[[2]](diffhunk://#diff-17410813d5b934e6b0249887b567a383ff1b6f70435521fd5042a6e4abe53670R1-R24)`)

### Subject Management Enhancements:
* Added a new API endpoint in `SubjectController` to retrieve subjects along with their associated teachers. (`[backend/src/main/java/edu/nbu/team13/gradecenter/controllers/SubjectController.javaR54-R60](diffhunk://#diff-e45776b18efd59cd9939ddf12ac2ffd96b7af568d8cfd361ef5edc14540053faR54-R60)`)
* Updated `SubjectService` and `SubjectRepository` to support fetching subjects with their teachers using a custom query and a new view interface `SubjectTeacherView`. (`[[1]](diffhunk://#diff-beaa482235113d0d41a2bace2abc156af1a361b28ffb74cc067ee67f52f66553R99-R102)`, `[[2]](diffhunk://#diff-27867cd179f7522067dbc9b8d5146a94ed4a177c17a31fcc63291723d890e14fR4-R24)`, `[[3]](diffhunk://#diff-5ab4c113d04e4cfc9d0ee2754bea1fb3774464c25c496cbb57e764a3cbda26bcR1-R11)`)

### Exception Handling:
* Introduced custom exceptions such as `InvalidDayOfWeek`, `TeacherDoesNotTeachSubject`, and `TimetableNotFound` to improve error handling for timetable operations. (`[[1]](diffhunk://#diff-df4954a6d53bf241732380e49d642de1cffa654c42fad492317c2d77b9f06eccR1-R7)`, `[[2]](diffhunk://#diff-5e7830047addab0f4ddd40449663a8a3ace83addf25cca99bb31102d851be563R1-R7)`, `[[3]](diffhunk://#diff-89ce26bf5b40a110a384779246b3ca0907bc0183e46ed5d9504c02b9646c441bR1-R7)`)

### Seeder Enhancements:
* Expanded the `SchoolAndSubjectSeeder` to include additional entities such as classes, students, teachers, and school years, enabling more comprehensive test data initialization. (`[backend/src/main/java/edu/nbu/team13/gradecenter/seeders/SchoolAndSubjectSeeder.javaR73-R126](diffhunk://#diff-8cc977f03984a28bfd610743d7b7beffdea276bf53e5e24d7eb5ebb564181837R73-R126)`)

### Miscellaneous Improvements:
* Added helper methods in services like `findById` for `SchoolYearService` and `TeacherService` to streamline entity retrieval and improve code reuse. (`[[1]](diffhunk://#diff-93ab018eceb55858531bf1002c11e66c621241a0a5913e0d0c9d3fe1ba47f254R81-R84)`, `[[2]](diffhunk://#diff-8eba0d722e14f4da20966e151a5271f27580a7815190524162d2d79b13630157R127-R137)`)